### PR TITLE
Fix missing include for drawdown level

### DIFF
--- a/IntegratedPA/Logger.mqh
+++ b/IntegratedPA/Logger.mqh
@@ -8,6 +8,7 @@
 #property version   "1.00"
 
 #include "Structures.mqh"
+#include "DrawdownController.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe para gerenciamento de logs                                |


### PR DESCRIPTION
## Summary
- include DrawdownController in Logger to fix missing ENUM_DRAWDOWN_LEVEL errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c7a93ac48320b80ef5bb1d3de359