### PR TITLE
Update stop loss with ATR multiplier

### DIFF
--- a/IntegratedPA/IntegratedPA_EA.mq5
+++ b/IntegratedPA/IntegratedPA_EA.mq5
@@ -345,7 +345,7 @@ bool ConfigureRiskParameters()
    for (int i = 0; i < ArraySize(g_assets); i++)
    {
       // Configurar parâmetros de risco específicos para cada ativo
-      g_riskManager.AddSymbol(g_assets[i].symbol, g_assets[i].riskPercentage, g_assets[i].maxLot);
+      g_riskManager.AddSymbol(g_assets[i].symbol, g_assets[i].riskPercentage, g_assets[i].maxLot, DEFAULT_ATR_MULTIPLIER);
 
       // ✅ CONFIGURAR STOPS ESPECÍFICOS POR SÍMBOLO (NOVOS VALORES)
       if (g_assets[i].symbol == "BIT$D")


### PR DESCRIPTION
## Summary
- add default `atrMultiplier` to `SymbolRiskParams`
- allow `AddSymbol` to set ATR multiplier
- integrate ATR multiplier into stop loss calculation
- update `IntegratedPA_EA` to use new API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a26bd516c83208171bed77907df9b