### PR TITLE
Add trading hours lock with pending-order cleanup

### DIFF
--- a/IntegratedPA/IntegratedPA_EA.mq5
+++ b/IntegratedPA/IntegratedPA_EA.mq5
@@ -60,6 +60,10 @@ input int TradingStartHour = 9;
 input int TradingStartMinute = 15;
 input int TradingEndHour = 16;
 input int TradingEndMinute = 30;
+input int MidBreakStartHour = 12;
+input int MidBreakStartMinute = 0;
+input int MidBreakEndHour = 14;
+input int MidBreakEndMinute = 0;
 
 //+------------------------------------------------------------------+
 //| Variáveis globais                                                |
@@ -551,7 +555,11 @@ int OnInit()
       g_logger.Error("Erro ao criar TradingHoursManager");
       return (INIT_FAILED);
    }
-   if (!g_hoursManager.Initialize(g_tradeExecutor, g_logger, TradingStartHour, TradingStartMinute, TradingEndHour, TradingEndMinute))
+   if (!g_hoursManager.Initialize(g_tradeExecutor, g_logger,
+                                 TradingStartHour, TradingStartMinute,
+                                 TradingEndHour, TradingEndMinute,
+                                 MidBreakStartHour, MidBreakStartMinute,
+                                 MidBreakEndHour, MidBreakEndMinute))
    {
       g_logger.Error("Falha ao inicializar TradingHoursManager");
       return (INIT_FAILED);

--- a/IntegratedPA/TradingHoursManager.mqh
+++ b/IntegratedPA/TradingHoursManager.mqh
@@ -1,0 +1,123 @@
+#ifndef TRADING_HOURS_MANAGER_MQH
+#define TRADING_HOURS_MANAGER_MQH
+#property strict
+
+#include "TradeExecutor.mqh"
+#include "Logger.mqh"
+
+class CTradingHoursManager
+  {
+private:
+   int            m_startHour;
+   int            m_startMinute;
+   int            m_endHour;
+   int            m_endMinute;
+   CTradeExecutor *m_executor;
+   CLogger        *m_logger;
+   bool           m_tradingAllowed;
+   datetime       m_lastDay;
+   bool           m_shutdownDone;
+
+   int MinutesOfDay(datetime t)
+     {
+      MqlDateTime dt;
+      TimeToStruct(t, dt);
+      return dt.hour * 60 + dt.min;
+     }
+
+public:
+   CTradingHoursManager()
+     {
+      m_startHour      = 9;
+      m_startMinute    = 15;
+      m_endHour        = 16;
+      m_endMinute      = 30;
+      m_executor       = NULL;
+      m_logger         = NULL;
+      m_tradingAllowed = true;
+      m_lastDay        = 0;
+      m_shutdownDone   = false;
+     }
+
+   bool Initialize(CTradeExecutor *executor, CLogger *logger,
+                   int startHour=9, int startMinute=15,
+                   int endHour=16, int endMinute=30)
+     {
+      if(executor==NULL || logger==NULL)
+         return false;
+      m_executor    = executor;
+      m_logger      = logger;
+      m_startHour   = startHour;
+      m_startMinute = startMinute;
+      m_endHour     = endHour;
+      m_endMinute   = endMinute;
+      m_lastDay     = TimeCurrent();
+      m_tradingAllowed = true;
+      m_shutdownDone   = false;
+      return true;
+     }
+
+   void Update()
+     {
+      if(m_executor==NULL)
+         return;
+      datetime now = TimeCurrent();
+      MqlDateTime dt;
+      TimeToStruct(now, dt);
+
+      int minutes      = dt.hour*60 + dt.min;
+      int startMinutes = m_startHour*60 + m_startMinute;
+      int endMinutes   = m_endHour*60 + m_endMinute;
+      int preBlock     = endMinutes - 3;
+
+      MqlDateTime ld; 
+      TimeToStruct(m_lastDay, ld);
+      if(dt.day!=ld.day || dt.mon!=ld.mon || dt.year!=ld.year)
+        {
+         m_shutdownDone = false;
+         m_lastDay      = now;
+        }
+
+      if(minutes >= preBlock && minutes < endMinutes)
+        {
+         if(!m_shutdownDone)
+           {
+            if(m_logger!=NULL)
+               m_logger.Info("Encerrando operações antes do fim da sessão");
+            m_executor.CancelAllPendingOrders();
+            m_executor.CloseAllPositions();
+            m_shutdownDone = true;
+           }
+         if(m_tradingAllowed)
+           {
+            m_executor.SetTradeAllowed(false);
+            m_tradingAllowed = false;
+           }
+         return;
+        }
+
+      if(minutes < startMinutes || minutes > endMinutes)
+        {
+         if(m_tradingAllowed)
+           {
+            m_executor.SetTradeAllowed(false);
+            m_tradingAllowed = false;
+            if(m_logger!=NULL)
+               m_logger.Info("Trading bloqueado fora do horário");
+           }
+         return;
+        }
+
+      if(!m_tradingAllowed)
+        {
+         m_executor.SetTradeAllowed(true);
+         m_tradingAllowed = true;
+         if(m_logger!=NULL)
+            m_logger.Info("Trading liberado");
+        }
+     }
+
+   bool IsTradingAllowed() const { return m_tradingAllowed; }
+  };
+
+#endif // TRADING_HOURS_MANAGER_MQH


### PR DESCRIPTION
## Summary
- create `CTradingHoursManager` class to control daily trading window
- add pending order cancellation routine in `CTradeExecutor`
- integrate trading-hours manager into main EA with configurable inputs
- update OnTick and OnTimer to enforce session rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a560b24888320bca94506f96aacd1